### PR TITLE
Implement standardised command execution framework and update policies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ These instructions apply to all Copilot-assisted contributions in this repositor
 ## Branching and Commit Rules
 
 - Never commit directly to `main` or `dev`.
-- Always work on a branch named `dev/branch-name`.
+- Always work on a branch named `feat/branch-name`.
 - One commit per change. Do not bundle unrelated work into a single commit.
 - Focus on one task at a time before moving to the next.
 

--- a/.github/workflows/project-standards.yml
+++ b/.github/workflows/project-standards.yml
@@ -34,8 +34,6 @@ jobs:
             "CODEOWNERS"
             "LICENSE"
             "VERSION"
-            "rust/.gitkeep"
-            "typescript/.gitkeep"
           )
 
           for file in "${required_files[@]}"; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ AI assistance is optional and secondary to human judgement. Maintainers own desi
 - Development branch: `dev`.
 - Production branch: `main`.
 - Promotion to `main` is done via pull request.
-- Never commit directly to `main` or `dev`. Always use a feature branch named `dev/branch-name`.
+- Never commit directly to `main` or `dev`. Always use a feature branch named `feat/branch-name`.
 - One commit per change — do not batch unrelated work.
 - Focus on one task at a time before moving on.
 - `VERSION` controls release intent and must use one of:

--- a/typescript/src/cli/commands/ping.ts
+++ b/typescript/src/cli/commands/ping.ts
@@ -1,0 +1,11 @@
+import type { Command } from "../router.js";
+
+export const pingCommand: Command = {
+    name: "ping",
+    description: "Check that the CLI is alive",
+    usage: "topgg ping",
+    aliases: ["health"],
+    run: ({ stdout }) => {
+        stdout("pong");
+    },
+};

--- a/typescript/src/cli/errors.ts
+++ b/typescript/src/cli/errors.ts
@@ -1,0 +1,9 @@
+export class CommandError extends Error {
+    public readonly code: number;
+
+    constructor(message: string, code = 1) {
+        super(message);
+        this.name = "CommandError";
+        this.code = code;
+    }
+}

--- a/typescript/src/cli/execute.ts
+++ b/typescript/src/cli/execute.ts
@@ -1,0 +1,40 @@
+import type { ParsedArgs } from "./args.js";
+import { CommandError } from "./errors.js";
+import { printHelp } from "./help.js";
+import { resolve } from "./router.js";
+
+function isHelpFlag(value: string | boolean | undefined): boolean {
+    return value === true;
+}
+
+export async function executeCommand(args: ParsedArgs): Promise<void> {
+    if (!args.command) {
+        printHelp();
+        return;
+    }
+
+    const command = resolve(args.command);
+
+    if (!command) {
+        throw new CommandError(
+            `Unknown command: ${args.command}\nRun 'topgg --help' to see available commands.`,
+            2,
+        );
+    }
+
+    if (isHelpFlag(args.flags.help) || isHelpFlag(args.flags.h)) {
+        if (command.usage) {
+            console.log(command.usage);
+            return;
+        }
+
+        printHelp();
+        return;
+    }
+
+    await command.run({
+        args,
+        stdout: console.log,
+        stderr: console.error,
+    });
+}

--- a/typescript/src/cli/help.ts
+++ b/typescript/src/cli/help.ts
@@ -15,8 +15,9 @@ export function printHelp(): void {
     if (commands.length > 0) {
         console.log("Commands:");
         for (const cmd of commands) {
+            const aliases = cmd.aliases && cmd.aliases.length > 0 ? ` (aliases: ${cmd.aliases.join(", ")})` : "";
             const usage = cmd.usage ? `  ${cmd.usage}` : "";
-            console.log(`  ${cmd.name.padEnd(16)}${cmd.description}${usage}`);
+            console.log(`  ${cmd.name.padEnd(16)}${cmd.description}${aliases}${usage}`);
         }
         console.log("");
     }

--- a/typescript/src/cli/register-default-commands.ts
+++ b/typescript/src/cli/register-default-commands.ts
@@ -1,0 +1,6 @@
+import { pingCommand } from "./commands/ping.js";
+import { register } from "./router.js";
+
+export function registerDefaultCommands(): void {
+    register(pingCommand);
+}

--- a/typescript/src/cli/router.ts
+++ b/typescript/src/cli/router.ts
@@ -1,16 +1,39 @@
 import type { ParsedArgs } from "./args.js";
 
+export interface CommandContext {
+    args: ParsedArgs;
+    stdout: (message: string) => void;
+    stderr: (message: string) => void;
+}
+
 export interface Command {
     name: string;
     description: string;
     usage?: string;
-    run: (args: ParsedArgs) => void | Promise<void>;
+    aliases?: string[];
+    run: (ctx: CommandContext) => void | Promise<void>;
 }
 
 const registry = new Map<string, Command>();
 
 export function register(command: Command): void {
+    if (registry.has(command.name)) {
+        throw new Error(`Command already registered: ${command.name}`);
+    }
+
     registry.set(command.name, command);
+
+    if (!command.aliases || command.aliases.length === 0) {
+        return;
+    }
+
+    for (const alias of command.aliases) {
+        if (registry.has(alias)) {
+            throw new Error(`Alias already registered: ${alias}`);
+        }
+
+        registry.set(alias, command);
+    }
 }
 
 export function resolve(name: string): Command | undefined {
@@ -18,5 +41,7 @@ export function resolve(name: string): Command | undefined {
 }
 
 export function all(): Command[] {
-    return Array.from(registry.values());
+    return Array.from(new Set(registry.values())).sort((a, b) => {
+        return a.name.localeCompare(b.name);
+    });
 }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,8 +1,12 @@
 import { parseArgs } from "./cli/args.js";
-import { resolve } from "./cli/router.js";
 import { printHelp, printVersion } from "./cli/help.js";
+import { registerDefaultCommands } from "./cli/register-default-commands.js";
+import { executeCommand } from "./cli/execute.js";
+import { CommandError } from "./cli/errors.js";
 
 async function main(): Promise<void> {
+    registerDefaultCommands();
+
     const args = parseArgs(process.argv);
 
     if (args.flags["version"]) {
@@ -10,23 +14,20 @@ async function main(): Promise<void> {
         return;
     }
 
-    if (!args.command || args.flags["help"] || args.flags["h"]) {
+    if (!args.command) {
         printHelp();
         return;
     }
 
-    const command = resolve(args.command);
-
-    if (!command) {
-        console.error(`Unknown command: ${args.command}`);
-        console.error(`Run 'topgg --help' to see available commands.`);
-        process.exit(1);
-    }
-
-    await command.run(args);
+    await executeCommand(args);
 }
 
 main().catch((err) => {
+    if (err instanceof CommandError) {
+        console.error(err.message);
+        process.exit(err.code);
+    }
+
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
 });


### PR DESCRIPTION
This pull request introduces a new extensible command system for the CLI, adds a default `ping` command, and updates project workflow and branch naming conventions. The CLI changes improve command registration, error handling, and help output, while the documentation and workflow updates align branch naming with new standards.

**CLI System Improvements:**

* Introduced a new command registration and execution system, including `Command` and `CommandContext` interfaces, support for command aliases, and a registry for commands and aliases in `router.ts`. This enables easier extension and management of CLI commands.
* Added a default `ping` command (`pingCommand` in `commands/ping.ts`) and a registration utility (`registerDefaultCommands` in `register-default-commands.ts`) that registers default commands on CLI startup. [[1]](diffhunk://#diff-369ffdd6065d9f1c3be9688a09b19b2ad460c37d10fd9347d3eecfe3ac7d22cbR1-R11) [[2]](diffhunk://#diff-cc17ba77cc7db792f7e741892c278fd082795fb82ee9e2eb36a496db146dcec8R1-R6) [[3]](diffhunk://#diff-95dcb9955cc8dc220ba5ef091d355a29db6542e150571ab5c248385740ac8d40L2-L29)
* Implemented centralized command execution logic in `execute.ts`, including improved error handling with a new `CommandError` class and better handling of unknown commands and help flags. [[1]](diffhunk://#diff-b20d68c9c81ba4f942faa9caf16e2a99150b083896a96caa74b925661e620911R1-R40) [[2]](diffhunk://#diff-a93b7a2d9a4f21a364490600dcb30374ebe9bcfe848434de653fad5963ae2520R1-R9) [[3]](diffhunk://#diff-95dcb9955cc8dc220ba5ef091d355a29db6542e150571ab5c248385740ac8d40L2-L29)
* Enhanced help output to display command aliases in `help.ts`.

**Project Workflow and Documentation Updates:**

* Updated branch naming conventions in documentation and workflow files to use `feat/branch-name` instead of `dev/branch-name`, and removed `.gitkeep` files from required files in the workflow. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L57-R57) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L20-R20) [[3]](diffhunk://#diff-148842fd4c63f722368d98049256f67e1d44c72adae41419df4b50bbfbeb8d92L37-L38)