### PR TITLE
Polish CLI command output and add ANSI styling with fallback

### DIFF
--- a/typescript/src/cli/commands/about.ts
+++ b/typescript/src/cli/commands/about.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "module";
+import { formatField } from "../output.js";
 import type { Command } from "../router.js";
 
 const require = createRequire(import.meta.url);
@@ -13,9 +14,10 @@ export const aboutCommand: Command = {
     description: "Show CLI metadata and runtime information",
     usage: "topgg about",
     run: ({ stdout }) => {
-        stdout(`${pkg.name} v${pkg.version}`);
+        stdout(`${pkg.name} ${pkg.version}`);
         stdout(pkg.description);
-        stdout(`Node.js ${process.version}`);
-        stdout(`Platform ${process.platform}`);
+        stdout("");
+        stdout(formatField("runtime", `Node.js ${process.version}`));
+        stdout(formatField("platform", process.platform));
     },
 };

--- a/typescript/src/cli/commands/ping.ts
+++ b/typescript/src/cli/commands/ping.ts
@@ -1,4 +1,5 @@
-import { CommandError } from "../errors.js";
+import { CommandError, UsageError } from "../errors.js";
+import { formatField, style } from "../output.js";
 import type { Command } from "../router.js";
 
 const TOP_GG_API_URL = "https://top.gg/api";
@@ -37,13 +38,13 @@ function resolveMultiTripCount(raw: string | boolean | undefined): number {
     const count = Number.parseInt(raw, 10);
 
     if (!Number.isFinite(count)) {
-        throw new CommandError("--count must be a number.", 2);
+        throw new UsageError("topgg ping", "--count must be a number.");
     }
 
     if (count < MIN_MULTI_TRIP_COUNT || count > MAX_MULTI_TRIP_COUNT) {
-        throw new CommandError(
+        throw new UsageError(
+            "topgg ping",
             `--count must be between ${MIN_MULTI_TRIP_COUNT} and ${MAX_MULTI_TRIP_COUNT}.`,
-            2,
         );
     }
 
@@ -58,7 +59,8 @@ export const pingCommand: Command = {
     run: async ({ args, stdout, stderr }) => {
         const multiTripCount = resolveMultiTripCount(args.flags.count);
 
-        stdout(`Pinging ${TOP_GG_API_URL}...`);
+        stdout(`${style.ok("Pinging")} ${TOP_GG_API_URL}...`);
+        stdout("");
 
         try {
             const coldRttMs = await measureTripMs();
@@ -74,13 +76,12 @@ export const pingCommand: Command = {
 
             const averageMultiTripMs = totalTripMs / multiTripCount;
 
-            stdout(`cold RTT: ${toMilliseconds(coldRttMs)}`);
-            stdout(`average RTT (${multiTripCount} samples): ${toMilliseconds(averageMultiTripMs)}`);
-            stdout(`warm RTT: ${toMilliseconds(warmRttMs)}`);
+            stdout(formatField("cold RTT", toMilliseconds(coldRttMs)));
+            stdout(formatField(`average RTT (${multiTripCount})`, toMilliseconds(averageMultiTripMs)));
+            stdout(formatField("warm RTT", toMilliseconds(warmRttMs)));
         } catch (error) {
             const detail = error instanceof Error ? error.message : String(error);
-            stderr(`Ping failed: ${detail}`);
-            throw new CommandError("Unable to reach the top.gg API.", 4);
+            throw new CommandError("Unable to reach the top.gg API.", 4, detail);
         }
     },
 };

--- a/typescript/src/cli/commands/search.ts
+++ b/typescript/src/cli/commands/search.ts
@@ -1,4 +1,4 @@
-import { CommandError, FeatureNotImplementedError } from "../errors.js";
+import { FeatureNotImplementedError, UsageError } from "../errors.js";
 import type { Command } from "../router.js";
 
 function getQuery(subcommand: string | undefined, positional: string[]): string {
@@ -7,7 +7,7 @@ function getQuery(subcommand: string | undefined, positional: string[]): string 
     });
 
     if (parts.length === 0) {
-        throw new CommandError("Usage: topgg search <query>", 2);
+        throw new UsageError("topgg search <query>");
     }
 
     return parts.join(" ");

--- a/typescript/src/cli/commands/stats.ts
+++ b/typescript/src/cli/commands/stats.ts
@@ -1,9 +1,9 @@
-import { CommandError, FeatureNotImplementedError } from "../errors.js";
+import { FeatureNotImplementedError, UsageError } from "../errors.js";
 import type { Command } from "../router.js";
 
 function getBotId(subcommand: string | undefined): string {
     if (!subcommand) {
-        throw new CommandError("Usage: topgg stats <bot-id>", 2);
+        throw new UsageError("topgg stats <bot-id>");
     }
 
     return subcommand;

--- a/typescript/src/cli/commands/votes.ts
+++ b/typescript/src/cli/commands/votes.ts
@@ -1,9 +1,9 @@
-import { CommandError, FeatureNotImplementedError } from "../errors.js";
+import { FeatureNotImplementedError, UsageError } from "../errors.js";
 import type { Command } from "../router.js";
 
 function getBotId(subcommand: string | undefined): string {
     if (!subcommand) {
-        throw new CommandError("Usage: topgg votes <bot-id>", 2);
+        throw new UsageError("topgg votes <bot-id>");
     }
 
     return subcommand;

--- a/typescript/src/cli/errors.ts
+++ b/typescript/src/cli/errors.ts
@@ -1,16 +1,25 @@
 export class CommandError extends Error {
     public readonly code: number;
+    public readonly hint?: string;
 
-    constructor(message: string, code = 1) {
+    constructor(message: string, code = 1, hint?: string) {
         super(message);
         this.name = "CommandError";
         this.code = code;
+        this.hint = hint;
+    }
+}
+
+export class UsageError extends CommandError {
+    constructor(usage: string, hint?: string) {
+        super(`Invalid command usage.`, 2, hint ?? `Run '${usage} --help' for usage details.`);
+        this.name = "UsageError";
     }
 }
 
 export class FeatureNotImplementedError extends CommandError {
     constructor(feature: string) {
-        super(`${feature} is not implemented yet.`, 3);
+        super(`${feature} is not implemented yet.`, 3, "This command is scaffolded and will be implemented in a later milestone.");
         this.name = "FeatureNotImplementedError";
     }
 }

--- a/typescript/src/cli/execute.ts
+++ b/typescript/src/cli/execute.ts
@@ -1,6 +1,7 @@
 import type { ParsedArgs } from "./args.js";
 import { CommandError } from "./errors.js";
 import { printHelp } from "./help.js";
+import { printCommandHelp } from "./output.js";
 import { resolve } from "./router.js";
 
 function isHelpFlag(value: string | boolean | undefined): boolean {
@@ -17,18 +18,14 @@ export async function executeCommand(args: ParsedArgs): Promise<void> {
 
     if (!command) {
         throw new CommandError(
-            `Unknown command: ${args.command}\nRun 'topgg --help' to see available commands.`,
+            `Unknown command '${args.command}'.`,
             2,
+            "Run 'topgg --help' to see available commands.",
         );
     }
 
     if (isHelpFlag(args.flags.help) || isHelpFlag(args.flags.h)) {
-        if (command.usage) {
-            console.log(command.usage);
-            return;
-        }
-
-        printHelp();
+        printCommandHelp(command);
         return;
     }
 

--- a/typescript/src/cli/help.ts
+++ b/typescript/src/cli/help.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "module";
 import { all } from "./router.js";
+import { formatField, style } from "./output.js";
 
 const require = createRequire(import.meta.url);
 const pkg = require("../../package.json") as { version: string };
@@ -7,24 +8,29 @@ const pkg = require("../../package.json") as { version: string };
 export function printHelp(): void {
     const commands = all();
 
-    console.log(`topgg-cli v${pkg.version}`);
-    console.log(`A command-line interface for the top.gg API.\n`);
-    console.log("Usage:");
-    console.log("  topgg <command> [subcommand] [flags]\n");
+    console.log(`${style.heading("topgg-cli")} ${style.ok(`v${pkg.version}`)}`);
+    console.log(`A command-line interface for the top.gg API.`);
+    console.log("");
+    console.log(style.heading("Usage"));
+    console.log(`  topgg <command> [subcommand] [flags]`);
+    console.log("");
 
     if (commands.length > 0) {
-        console.log("Commands:");
+        console.log(style.heading("Commands"));
         for (const cmd of commands) {
-            const aliases = cmd.aliases && cmd.aliases.length > 0 ? ` (aliases: ${cmd.aliases.join(", ")})` : "";
-            const usage = cmd.usage ? `  ${cmd.usage}` : "";
-            console.log(`  ${cmd.name.padEnd(16)}${cmd.description}${aliases}${usage}`);
+            const aliases = cmd.aliases && cmd.aliases.length > 0 ? ` [aliases: ${cmd.aliases.join(", ")}]` : "";
+            console.log(`  ${cmd.name.padEnd(12)}${cmd.description}${aliases}`);
+
+            if (cmd.usage) {
+                console.log(`    ${formatField("usage", cmd.usage)}`);
+            }
         }
         console.log("");
     }
 
-    console.log("Flags:");
-    console.log("  --help, -h    Show help for a command");
-    console.log("  --version     Show the current version");
+    console.log(style.heading("Global Flags"));
+    console.log(`  ${formatField("--help, -h", "Show help for a command")}`);
+    console.log(`  ${formatField("--version", "Show the current version")}`);
 }
 
 export function printVersion(): void {

--- a/typescript/src/cli/output.ts
+++ b/typescript/src/cli/output.ts
@@ -1,0 +1,85 @@
+import type { Command } from "./router.js";
+
+const FIELD_WIDTH = 18;
+
+function isForcedOn(): boolean {
+    const value = process.env.FORCE_COLOR;
+
+    if (value === undefined) {
+        return false;
+    }
+
+    return value !== "0";
+}
+
+function isForcedOff(): boolean {
+    return process.env.NO_COLOR !== undefined || process.env.TERM === "dumb";
+}
+
+function supportsAnsi(): boolean {
+    if (isForcedOn()) {
+        return true;
+    }
+
+    if (isForcedOff()) {
+        return false;
+    }
+
+    return Boolean(process.stdout.isTTY || process.stderr.isTTY);
+}
+
+const ANSI_ENABLED = supportsAnsi();
+
+function colour(code: string, text: string): string {
+    if (!ANSI_ENABLED) {
+        return text;
+    }
+
+    return `\u001b[${code}m${text}\u001b[0m`;
+}
+
+export const style = {
+    heading(text: string): string {
+        return colour("1", text);
+    },
+    muted(text: string): string {
+        return colour("2", text);
+    },
+    ok(text: string): string {
+        return colour("32", text);
+    },
+    warn(text: string): string {
+        return colour("33", text);
+    },
+    err(text: string): string {
+        return colour("31", text);
+    },
+};
+
+export function formatField(label: string, value: string): string {
+    return `${style.muted(label.padEnd(FIELD_WIDTH))}${value}`;
+}
+
+export function printError(
+    stderr: (message: string) => void,
+    message: string,
+    hint?: string,
+): void {
+    stderr(`${style.err("Error")}: ${message}`);
+
+    if (hint) {
+        stderr(`${style.warn("Hint")}: ${hint}`);
+    }
+}
+
+export function printCommandHelp(command: Command): void {
+    console.log(`${style.heading(command.name)} - ${command.description}`);
+
+    if (command.aliases && command.aliases.length > 0) {
+        console.log(formatField("Aliases", command.aliases.join(", ")));
+    }
+
+    if (command.usage) {
+        console.log(formatField("Usage", command.usage));
+    }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -3,6 +3,7 @@ import { printHelp, printVersion } from "./cli/help.js";
 import { registerDefaultCommands } from "./cli/register-default-commands.js";
 import { executeCommand } from "./cli/execute.js";
 import { CommandError } from "./cli/errors.js";
+import { printError } from "./cli/output.js";
 
 async function main(): Promise<void> {
     registerDefaultCommands();
@@ -24,11 +25,11 @@ async function main(): Promise<void> {
 
 main().catch((err) => {
     if (err instanceof CommandError) {
-        console.error(err.message);
+        printError(console.error, err.message, err.hint);
         process.exit(err.code);
     }
 
-    console.error(err instanceof Error ? err.message : String(err));
+    printError(console.error, err instanceof Error ? err.message : String(err));
     process.exit(1);
 });
 


### PR DESCRIPTION
This pull request introduces improvements to CLI error handling, output formatting, and help messaging for a more user-friendly and consistent experience. The changes include the introduction of a new `UsageError` class for better usage-related error reporting, ANSI color support for styled output, and a refactor of help and command output to use consistent formatting.

**Error handling and reporting improvements:**

* Added a new `UsageError` class to distinguish usage errors from general command errors, providing clearer error messages and hints for users. `FeatureNotImplementedError` now also includes a hint about future implementation. The `CommandError` class now supports an optional `hint` property for additional guidance.
* Updated all CLI commands (`about`, `ping`, `search`, `stats`, `votes`) to throw `UsageError` instead of `CommandError` for usage-related mistakes, ensuring consistent and actionable error messages. [[1]](diffhunk://#diff-369ffdd6065d9f1c3be9688a09b19b2ad460c37d10fd9347d3eecfe3ac7d22cbL40-L46) [[2]](diffhunk://#diff-56b0baca2e1608f365d9028cfc28b3d3ec271919ba9f3db277a23d450d44126cL1-R1) [[3]](diffhunk://#diff-56b0baca2e1608f365d9028cfc28b3d3ec271919ba9f3db277a23d450d44126cL10-R10) [[4]](diffhunk://#diff-9cc116f7cc9a078f085c55ee297dd2379f2a5fc1d12fe119fcd84c01ffd34b82L1-R6) [[5]](diffhunk://#diff-ca8aff9d96316a38a36be6d242c418e6f3a25add2e8962363b77c5b53b4d9363L1-R6)

**Output formatting and styling:**

* Introduced a new `output.ts` module with ANSI color support and utility functions (`style`, `formatField`, `printError`, `printCommandHelp`) to standardize and enhance the appearance of CLI output.
* Refactored all command outputs and help messages to use the new formatting utilities, improving readability and consistency across commands and help screens. [[1]](diffhunk://#diff-c1edfd7a3c35f71f9df37a268e45bb36b3f07b241cb1306cb253f4b18332e268R3-R33) [[2]](diffhunk://#diff-c2dfe6e72ae7fd7d1564ce1bb8ece39cab74df7ce68b828c463772d3ae591bacR2) [[3]](diffhunk://#diff-c2dfe6e72ae7fd7d1564ce1bb8ece39cab74df7ce68b828c463772d3ae591bacL16-R21) [[4]](diffhunk://#diff-369ffdd6065d9f1c3be9688a09b19b2ad460c37d10fd9347d3eecfe3ac7d22cbL61-R63) [[5]](diffhunk://#diff-369ffdd6065d9f1c3be9688a09b19b2ad460c37d10fd9347d3eecfe3ac7d22cbL77-R84) [[6]](diffhunk://#diff-b20d68c9c81ba4f942faa9caf16e2a99150b083896a96caa74b925661e620911R4) [[7]](diffhunk://#diff-b20d68c9c81ba4f942faa9caf16e2a99150b083896a96caa74b925661e620911L20-R28)

**CLI help and version display enhancements:**

* Updated the main help and per-command help output to use styled headings, consistent field formatting, and clearer usage instructions. [[1]](diffhunk://#diff-c1edfd7a3c35f71f9df37a268e45bb36b3f07b241cb1306cb253f4b18332e268R3-R33) [[2]](diffhunk://#diff-e99e93f64a4679fdc1804914288f4269695c40317103e6f9c58fd67074fc7638R1-R85)
* Improved error reporting in the CLI entrypoint to use the new `printError` function, displaying both error messages and hints when available. [[1]](diffhunk://#diff-95dcb9955cc8dc220ba5ef091d355a29db6542e150571ab5c248385740ac8d40R6) [[2]](diffhunk://#diff-95dcb9955cc8dc220ba5ef091d355a29db6542e150571ab5c248385740ac8d40L27-R32)